### PR TITLE
Fix number shifting for locales using comma as decimal delimiter

### DIFF
--- a/src/Providers/Implementations/NumberProvider.cs
+++ b/src/Providers/Implementations/NumberProvider.cs
@@ -13,7 +13,7 @@ namespace Shifter.Providers
         {
             result = null;
 
-            if (!float.TryParse(match.Value, out float value))
+            if (!float.TryParse(match.Value, NumberStyles.Any, CultureInfo.InvariantCulture, out float value))
             {
                 return false;
             }


### PR DESCRIPTION
Currently, number shifting with decimals does not work when you have regional settings (e.g. German) where dots are thousands separators and commas are used for delimiting decimals.

That does not apply to code, so there's a mismatch when parsing string as float without specifying a culture (which uses dots for decimals separation).

BTW: I'm wondering why you are using float (single) rather than double as double can work with larger numbers (or to be precise: numbers with more digits)?
